### PR TITLE
Whirlpool client 0.23.37

### DIFF
--- a/src/main/java/com/samourai/wallet/api/backend/BackendApi.java
+++ b/src/main/java/com/samourai/wallet/api/backend/BackendApi.java
@@ -216,7 +216,8 @@ public class BackendApi {
 
     // address reuse
     if (pushTxResponse.error != null && PushTxResponse.PushTxError.CODE_VIOLATION_STRICT_MODE_VOUTS.equals(pushTxResponse.error.code)) {
-      throw new PushTxAddressReuseException();
+      Collection<Integer> adressReuseOutputIndexs = (Collection<Integer>)pushTxResponse.error.message;
+      throw new PushTxAddressReuseException(adressReuseOutputIndexs);
     }
 
     // other error

--- a/src/main/java/com/samourai/wallet/api/backend/beans/HttpException.java
+++ b/src/main/java/com/samourai/wallet/api/backend/beans/HttpException.java
@@ -8,6 +8,11 @@ public class HttpException extends Exception {
     this.responseBody = responseBody;
   }
 
+  public HttpException(String message, String responseBody) {
+    super(message);
+    this.responseBody = responseBody;
+  }
+
   public String getResponseBody() {
     return responseBody;
   }

--- a/src/main/java/com/samourai/wallet/api/backend/beans/PushTxAddressReuseException.java
+++ b/src/main/java/com/samourai/wallet/api/backend/beans/PushTxAddressReuseException.java
@@ -1,7 +1,19 @@
 package com.samourai.wallet.api.backend.beans;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
 public class PushTxAddressReuseException extends Exception {
-  public PushTxAddressReuseException() {
-    super();
+  private List<Integer> adressReuseOutputIndexs;
+
+  public PushTxAddressReuseException(Collection<Integer> adressReuseOutputIndexs) {
+    super("Address reuse detected for outputs: "+ Arrays.toString(adressReuseOutputIndexs.toArray()));
+    this.adressReuseOutputIndexs = new LinkedList<>(adressReuseOutputIndexs);
+  }
+
+  public List<Integer> getAdressReuseOutputIndexs() {
+    return adressReuseOutputIndexs;
   }
 }

--- a/src/main/java/com/samourai/wallet/api/backend/beans/PushTxResponse.java
+++ b/src/main/java/com/samourai/wallet/api/backend/beans/PushTxResponse.java
@@ -16,6 +16,14 @@ public class PushTxResponse {
 
     public Object message;
     public String code;
+
+    @Override
+    public String toString() {
+      return "PushTxError{" +
+              "message=" + message +
+              ", code='" + code + '\'' +
+              '}';
+    }
   }
 
   @Override

--- a/src/main/java/com/samourai/wallet/bip47/rpc/BIP47Account.java
+++ b/src/main/java/com/samourai/wallet/bip47/rpc/BIP47Account.java
@@ -29,7 +29,7 @@ public class BIP47Account extends HD_Account {
      *
      */
     public BIP47Account(NetworkParameters params, DeterministicKey wKey, int child) {
-        super(params, wKey, "", child);
+        super(params, wKey, child);
         strPaymentCode = createPaymentCodeFromAccountKey();
     }
 

--- a/src/main/java/com/samourai/wallet/bip47/rpc/BIP47Wallet.java
+++ b/src/main/java/com/samourai/wallet/bip47/rpc/BIP47Wallet.java
@@ -12,8 +12,6 @@ import org.bitcoinj.crypto.MnemonicException;
  */
 public class BIP47Wallet extends HD_Wallet {
 
-    private BIP47Account mAccount = null;
-
     /**
      * Constructor for wallet.
      *
@@ -22,15 +20,10 @@ public class BIP47Wallet extends HD_Wallet {
      * @param NetworkParameters params
      * @param byte[] seed seed for this wallet
      * @param String passphrase optional BIP39 passphrase
-     * @param int nbAccounts number of accounts to create
      *
      */
-    public BIP47Wallet(int purpose, MnemonicCode mc, NetworkParameters params, byte[] seed, String passphrase, int nbAccounts) throws MnemonicException.MnemonicLengthException {
-
-        super(purpose, mc, params, seed, passphrase, nbAccounts);
-
-        mAccount = new BIP47Account(params, mRoot, 0);
-
+    public BIP47Wallet(int purpose, MnemonicCode mc, NetworkParameters params, byte[] seed, String passphrase) throws MnemonicException.MnemonicLengthException {
+        super(purpose, mc, params, seed, passphrase);
     }
 
     /**
@@ -38,23 +31,7 @@ public class BIP47Wallet extends HD_Wallet {
      * @param hdWallet
      */
     public BIP47Wallet(HD_Wallet hdWallet) {
-        this(47, hdWallet, 1);
-    }
-
-    /**
-     * Constructor for wallet.
-     *
-     * @param int purpose
-     * @param HD_Wallet hdWallet to copy from
-     * @param int nbAccounts
-     *
-     */
-    public BIP47Wallet(int purpose, HD_Wallet hdWallet, int nbAccounts) {
-
-        super(purpose, hdWallet, nbAccounts);
-
-        mAccount = new BIP47Account(mParams, mRoot, 0);
-
+        super(47, hdWallet);
     }
 
     /**
@@ -65,8 +42,9 @@ public class BIP47Wallet extends HD_Wallet {
      * @return Account
      *
      */
+    @Override
     public BIP47Account getAccount(int accountId) {
-        return mAccount;
+        return new BIP47Account(mParams, mRoot, 0);
     }
 
 }

--- a/src/main/java/com/samourai/wallet/cahoots/stonewallx2/Stonewallx2Service.java
+++ b/src/main/java/com/samourai/wallet/cahoots/stonewallx2/Stonewallx2Service.java
@@ -375,7 +375,7 @@ public class Stonewallx2Service extends AbstractCahootsService<STONEWALLx2> {
         //
 
         HD_Wallet bip84Wallet = cahootsWallet.getBip84Wallet();
-        String zpub = bip84Wallet.getAccountAt(stonewall1.getAccount()).zpubstr();
+        String zpub = bip84Wallet.getAccount(stonewall1.getAccount()).zpubstr();
         HashMap<MyTransactionOutPoint, Triple<byte[], byte[], String>> inputsB = new HashMap<MyTransactionOutPoint, Triple<byte[], byte[], String>>();
 
         for (CahootsUtxo utxo : selectedUTXO) {

--- a/src/main/java/com/samourai/wallet/client/BipWallet.java
+++ b/src/main/java/com/samourai/wallet/client/BipWallet.java
@@ -28,7 +28,7 @@ public class BipWallet {
   }
 
   public String getPub(AddressType addressType) {
-    HD_Account hdAccount = bipWallet.getAccountAt(account.getAccountIndex());
+    HD_Account hdAccount = bipWallet.getAccount(account.getAccountIndex());
     switch (addressType) {
       case LEGACY:
         return hdAccount.xpubstr();

--- a/src/main/java/com/samourai/wallet/client/indexHandler/AbstractIndexHandler.java
+++ b/src/main/java/com/samourai/wallet/client/indexHandler/AbstractIndexHandler.java
@@ -38,7 +38,7 @@ public abstract class AbstractIndexHandler implements IIndexHandler {
   @Override
   public synchronized void confirmUnconfirmed(final int confirmed) {
     if (confirmed >= get()) {
-      set(confirmed + 1);
+      set(confirmed + 1, false);
     }
 
     Iterator<Integer> it = unconfirmedIndexs.iterator();
@@ -63,4 +63,14 @@ public abstract class AbstractIndexHandler implements IIndexHandler {
   public synchronized void cancelUnconfirmed(int unconfirmed) {
     unconfirmedIndexs.remove(unconfirmed);
   }
+
+  @Override
+  public void set(int value, boolean allowDecrement) {
+    if (!allowDecrement && value <= get()) {
+      return; // deny decrement
+    }
+    set(value);
+  }
+
+  protected abstract void set(int value);
 }

--- a/src/main/java/com/samourai/wallet/client/indexHandler/IIndexHandler.java
+++ b/src/main/java/com/samourai/wallet/client/indexHandler/IIndexHandler.java
@@ -7,7 +7,7 @@ public interface IIndexHandler {
 
   int get();
 
-  void set(int value);
+  void set(int value, boolean allowDecrement);
 
   int getAndIncrementUnconfirmed();
 

--- a/src/main/java/com/samourai/wallet/client/indexHandler/MemoryIndexHandler.java
+++ b/src/main/java/com/samourai/wallet/client/indexHandler/MemoryIndexHandler.java
@@ -25,7 +25,7 @@ public class MemoryIndexHandler extends AbstractIndexHandler {
   }
 
   @Override
-  public synchronized void set(int value) {
+  protected synchronized void set(int value) {
     index = value;
   }
 }

--- a/src/main/java/com/samourai/wallet/hd/HD_Account.java
+++ b/src/main/java/com/samourai/wallet/hd/HD_Account.java
@@ -14,7 +14,6 @@ import org.json.JSONObject;
 public class HD_Account {
 
     protected DeterministicKey aKey = null;
-    private String strLabel = null;
     protected int mAID; // accountIndex
 
     private HD_Chain mReceive = null;
@@ -28,10 +27,9 @@ public class HD_Account {
 
     protected HD_Account() { ; }
 
-    public HD_Account(NetworkParameters params, DeterministicKey mKey, String label, int child) {
+    public HD_Account(NetworkParameters params, DeterministicKey mKey, int child) {
 
         mParams = params;
-        strLabel = label;
         mAID = child;
 
         // L0PRV & STDVx: private derivation.
@@ -48,10 +46,9 @@ public class HD_Account {
 
     }
 
-    public HD_Account(NetworkParameters params, String xpub, String label, int child) throws AddressFormatException {
+    public HD_Account(NetworkParameters params, String xpub, int child) throws AddressFormatException {
 
         mParams = params;
-        strLabel = label;
         mAID = child;
 
         // assign master key to account key
@@ -80,14 +77,6 @@ public class HD_Account {
 
         return strZPUB;
 
-    }
-
-    public String getLabel() {
-        return strLabel;
-    }
-
-    public void setLabel(String label) {
-        strLabel = label;
     }
 
     public int getId() {

--- a/src/main/java/com/samourai/wallet/hd/WALLET_INDEX.java
+++ b/src/main/java/com/samourai/wallet/hd/WALLET_INDEX.java
@@ -1,0 +1,83 @@
+package com.samourai.wallet.hd;
+
+import com.samourai.whirlpool.client.wallet.beans.WhirlpoolAccount;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum WALLET_INDEX {
+
+  BIP44_RECEIVE(WhirlpoolAccount.DEPOSIT, AddressType.LEGACY, Chain.RECEIVE),
+  BIP44_CHANGE(WhirlpoolAccount.DEPOSIT, AddressType.LEGACY, Chain.CHANGE),
+
+  BIP49_RECEIVE(WhirlpoolAccount.DEPOSIT, AddressType.SEGWIT_COMPAT, Chain.RECEIVE),
+  BIP49_CHANGE(WhirlpoolAccount.DEPOSIT, AddressType.SEGWIT_COMPAT, Chain.CHANGE),
+
+  BIP84_RECEIVE(WhirlpoolAccount.DEPOSIT, AddressType.SEGWIT_NATIVE, Chain.RECEIVE),
+  BIP84_CHANGE(WhirlpoolAccount.DEPOSIT, AddressType.SEGWIT_NATIVE, Chain.CHANGE),
+
+  PREMIX_RECEIVE(WhirlpoolAccount.PREMIX, AddressType.SEGWIT_NATIVE, Chain.RECEIVE),
+  PREMIX_CHANGE(WhirlpoolAccount.PREMIX, AddressType.SEGWIT_NATIVE, Chain.CHANGE),
+
+  POSTMIX_RECEIVE(WhirlpoolAccount.POSTMIX, AddressType.SEGWIT_NATIVE, Chain.RECEIVE),
+  POSTMIX_CHANGE(WhirlpoolAccount.POSTMIX, AddressType.SEGWIT_NATIVE, Chain.CHANGE),
+
+  BADBANK_RECEIVE(WhirlpoolAccount.BADBANK, AddressType.SEGWIT_NATIVE, Chain.RECEIVE),
+  BADBANK_CHANGE(WhirlpoolAccount.BADBANK, AddressType.SEGWIT_NATIVE, Chain.CHANGE);
+
+  private static final Logger log = LoggerFactory.getLogger(WALLET_INDEX.class.getSimpleName());
+  private WhirlpoolAccount account;
+  private AddressType addressType;
+  private Chain chain;
+
+  WALLET_INDEX(WhirlpoolAccount account, AddressType addressType, Chain chain) {
+    this.account = account;
+    this.addressType = addressType;
+    this.chain = chain;
+  }
+
+  public static WALLET_INDEX find(WhirlpoolAccount account, AddressType addressType, Chain chain) {
+    for (WALLET_INDEX walletIndex : WALLET_INDEX.values()) {
+      if (walletIndex.account == account && walletIndex.addressType == addressType && walletIndex.chain == chain) {
+        return walletIndex;
+      }
+    }
+    log.error("WALLET_INDEX not found: "+account+"/"+addressType+"/"+chain);
+    return null;
+  }
+
+  public static WALLET_INDEX findChangeIndex(int account, int addressType) {
+    if (account == WhirlpoolAccount.POSTMIX.getAccountIndex()) {
+      return WALLET_INDEX.POSTMIX_CHANGE;
+    }
+    /* if (account == WhirlpoolAccount.PREMIX.getAccountIndex()) {
+      return WALLET_INDEX.PREMIX_CHANGE;
+    } */
+    if (addressType == 84) {
+      return WALLET_INDEX.BIP84_CHANGE;
+    } else if (addressType == 49) {
+      return WALLET_INDEX.BIP49_CHANGE;
+    } else {
+      return WALLET_INDEX.BIP44_CHANGE;
+    }
+  }
+
+  public WhirlpoolAccount getAccount() {
+    return account;
+  }
+
+  public int getAccountIndex() {
+    return account.getAccountIndex();
+  }
+
+  public AddressType getAddressType() {
+    return addressType;
+  }
+
+  public Chain getChain() {
+    return chain;
+  }
+
+  public int getChainIndex() {
+    return chain.getIndex();
+  }
+}

--- a/src/main/java/com/samourai/wallet/segwit/bech32/Bech32.java
+++ b/src/main/java/com/samourai/wallet/segwit/bech32/Bech32.java
@@ -4,153 +4,170 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Locale;
 
+import com.samourai.wallet.util.Triple;
+
 public class Bech32 {
 
-    private static final String CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+  private static final String CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+  private static final int BECH32M_CONST = 0x2bc830a3;
 
-    public static String bech32Encode(String hrp, byte[] data) {
+  public static final int BECH32 = 1;
+  public static final int BECH32M = 2;
 
-        byte[] chk = createChecksum(hrp.getBytes(), data);
-        byte[] combined = new byte[chk.length + data.length];
+  public static String bech32Encode(String hrp, byte[] data, int spec) {
 
-        System.arraycopy(data, 0, combined, 0, data.length);
-        System.arraycopy(chk, 0, combined, data.length, chk.length);
+      byte[] chk = createChecksum(hrp.getBytes(), data, spec);
+      byte[] combined = new byte[chk.length + data.length];
 
-        byte[] xlat = new byte[combined.length];
-        for(int i = 0; i < combined.length; i++)   {
-            xlat[i] = (byte)CHARSET.charAt(combined[i]);
-        }
+      System.arraycopy(data, 0, combined, 0, data.length);
+      System.arraycopy(chk, 0, combined, data.length, chk.length);
 
-        byte[] ret = new byte[hrp.getBytes().length + xlat.length + 1];
-        System.arraycopy(hrp.getBytes(), 0, ret, 0, hrp.getBytes().length);
-        System.arraycopy(new byte[] { 0x31 }, 0, ret, hrp.getBytes().length, 1);
-        System.arraycopy(xlat, 0, ret, hrp.getBytes().length + 1, xlat.length);
+      byte[] xlat = new byte[combined.length];
+      for(int i = 0; i < combined.length; i++)   {
+          xlat[i] = (byte)CHARSET.charAt(combined[i]);
+      }
 
-        return new String(ret);
-    }
+      byte[] ret = new byte[hrp.getBytes().length + xlat.length + 1];
+      System.arraycopy(hrp.getBytes(), 0, ret, 0, hrp.getBytes().length);
+      System.arraycopy(new byte[] { 0x31 }, 0, ret, hrp.getBytes().length, 1);
+      System.arraycopy(xlat, 0, ret, hrp.getBytes().length + 1, xlat.length);
 
-    public static Pair<String, byte[]> bech32Decode(String bech) throws Exception  {
+      return new String(ret);
+  }
 
-        byte[] buffer = bech.getBytes();
-        for(byte b : buffer)   {
-            if(b < 0x21 || b > 0x7e)    {
-                throw new Exception("bech32 characters out of range");
-            }
-        }
+  public static Triple<String, byte[], Integer> bech32Decode(String bech) {
 
-        if(!bech.equals(bech.toLowerCase(Locale.ROOT)) && !bech.equals(bech.toUpperCase(Locale.ROOT)))  {
-            throw new Exception("bech32 cannot mix upper and lower case");
-        }
+      byte[] buffer = bech.getBytes();
+      for(byte b : buffer)   {
+          if(b < (byte)0x21 || b > (byte)0x7e)    {
+              return null;
+          }
+      }
 
-        bech = bech.toLowerCase();
-        int pos = bech.lastIndexOf("1");
-        if(pos < 1)    {
-            throw new Exception("bech32 missing separator");
-        }
-        else if(pos + 7 > bech.length())    {
-            throw new Exception("bech32 separator misplaced");
-        }
-        else if(bech.length() < 8)    {
-            throw new Exception("bech32 input too short");
-        }
-        else if(bech.length() > 90)    {
-            throw new Exception("bech32 input too long");
-        }
-        else    {
-            ;
-        }
+      if(!bech.equals(bech.toLowerCase(Locale.ROOT)) && !bech.equals(bech.toUpperCase(Locale.ROOT)))  {
+          return null;
+      }
 
-        String s = bech.substring(pos + 1);
-        for(int i = 0; i < s.length(); i++) {
-            if(CHARSET.indexOf(s.charAt(i)) == -1)    {
-                throw new Exception("bech32 characters  out of range");
-            }
-        }
+      bech = bech.toLowerCase();
+      int pos = bech.lastIndexOf("1");
+      if(pos < 1)    {
+          return null;
+      }
+      else if(pos + 7 > bech.length())    {
+          return null;
+      }
+      else if(bech.length() < 8)    {
+          return null;
+      }
+      else if(bech.length() > 90)    {
+          return null;
+      }
+      else    {
+          ;
+      }
 
-        byte[] hrp = bech.substring(0, pos).getBytes();
+      String s = bech.substring(pos + 1);
+      for(int i = 0; i < s.length(); i++) {
+          if(CHARSET.indexOf(s.charAt(i)) == -1)    {
+              return null;
+          }
+      }
 
-        byte[] data = new byte[bech.length() - pos - 1];
-        for(int j = 0, i = pos + 1; i < bech.length(); i++, j++) {
-            data[j] = (byte)CHARSET.indexOf(bech.charAt(i));
-        }
+      byte[] hrp = bech.substring(0, pos).getBytes();
 
-        if (!verifyChecksum(hrp, data)) {
-            throw new Exception("invalid bech32 checksum");
-        }
+      byte[] data = new byte[bech.length() - pos - 1];
+      for(int j = 0, i = pos + 1; i < bech.length(); i++, j++) {
+          data[j] = (byte)CHARSET.indexOf(bech.charAt(i));
+      }
 
-        byte[] ret = new byte[data.length - 6];
-        System.arraycopy(data, 0, ret, 0, data.length - 6);
+      int spec = verifyChecksum(hrp, data);
+      if (spec == 0) {
+          return null;
+      }
 
-        return Pair.of(new String(hrp), ret);
-    }
+      byte[] ret = new byte[data.length - 6];
+      System.arraycopy(data, 0, ret, 0, data.length - 6);
 
-    private static int polymod(byte[] values)  {
+      return Triple.of(new String(hrp), ret, spec);
+  }
 
-        final int[] GENERATORS = { 0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3 };
+  private static int polymod(byte[] values)  {
 
-        int chk = 1;
+      final int[] GENERATORS = { 0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3 };
 
-        for(byte b : values)   {
-            byte top = (byte)(chk >> 0x19);
-            chk = b ^ ((chk & 0x1ffffff) << 5);
-            for(int i = 0; i < 5; i++)   {
-                chk ^= ((top >> i) & 1) == 1 ? GENERATORS[i] : 0;
-            }
-        }
+      int chk = 1;
 
-        return chk;
-    }
+      for(byte b : values)   {
+          byte top = (byte)(chk >> 0x19);
+          chk = b ^ ((chk & 0x1ffffff) << 5);
+          for(int i = 0; i < 5; i++)   {
+              chk ^= ((top >> i) & 1) != 0 ? GENERATORS[i] : 0;
+          }
+      }
 
-    private static byte[] hrpExpand(byte[] hrp) {
+      return chk;
+  }
 
-        byte[] buf1 = new byte[hrp.length];
-        byte[] buf2 = new byte[hrp.length];
-        byte[] mid = new byte[1];
+  private static byte[] hrpExpand(byte[] hrp) {
 
-        for (int i = 0; i < hrp.length; i++)   {
-            buf1[i] = (byte)(hrp[i] >> 5);
-        }
-        mid[0] = 0x00;
-        for (int i = 0; i < hrp.length; i++)   {
-            buf2[i] = (byte)(hrp[i] & 0x1f);
-        }
+      byte[] buf1 = new byte[hrp.length];
+      byte[] buf2 = new byte[hrp.length];
+      byte[] mid = new byte[1];
 
-        byte[] ret = new byte[(hrp.length * 2) + 1];
-        System.arraycopy(buf1, 0, ret, 0, buf1.length);
-        System.arraycopy(mid, 0, ret, buf1.length, mid.length);
-        System.arraycopy(buf2, 0, ret, buf1.length + mid.length, buf2.length);
+      for (int i = 0; i < hrp.length; i++)   {
+          buf1[i] = (byte)(hrp[i] >> 5);
+      }
+      mid[0] = (byte)0x00;
+      for (int i = 0; i < hrp.length; i++)   {
+          buf2[i] = (byte)(hrp[i] & 0x1f);
+      }
 
-        return ret;
-    }
+      byte[] ret = new byte[(hrp.length * 2) + 1];
+      System.arraycopy(buf1, 0, ret, 0, buf1.length);
+      System.arraycopy(mid, 0, ret, buf1.length, mid.length);
+      System.arraycopy(buf2, 0, ret, buf1.length + mid.length, buf2.length);
 
-    private static boolean verifyChecksum(byte[] hrp, byte[] data) {
+      return ret;
+  }
 
-        byte[] exp = hrpExpand(hrp);
+  private static int verifyChecksum(byte[] hrp, byte[] data) {
 
-        byte[] values = new byte[exp.length + data.length];
-        System.arraycopy(exp, 0, values, 0, exp.length);
-        System.arraycopy(data, 0, values, exp.length, data.length);
+      byte[] exp = hrpExpand(hrp);
 
-        return (1 == polymod(values));
-    }
+      byte[] values = new byte[exp.length + data.length];
+      System.arraycopy(exp, 0, values, 0, exp.length);
+      System.arraycopy(data, 0, values, exp.length, data.length);
 
-    private static byte[] createChecksum(byte[] hrp, byte[] data)  {
+      switch (polymod(values)) {
+        case 1:
+          return BECH32;
+        case BECH32M_CONST:
+          return BECH32M;
+        default:
+          return 0;
+      }
 
-        final byte[] zeroes = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-        byte[] expanded = hrpExpand(hrp);
-        byte[] values = new byte[zeroes.length + expanded.length + data.length];
+  }
 
-        System.arraycopy(expanded, 0, values, 0, expanded.length);
-        System.arraycopy(data, 0, values, expanded.length, data.length);
-        System.arraycopy(zeroes, 0, values, expanded.length + data.length, zeroes.length);
+  private static byte[] createChecksum(byte[] hrp, byte[] data, int spec)  {
 
-        int polymod = polymod(values) ^ 1;
-        byte[] ret = new byte[6];
-        for(int i = 0; i < ret.length; i++)   {
-            ret[i] = (byte)((polymod >> 5 * (5 - i)) & 0x1f);
-        }
+      final byte[] zeroes = new byte[] { (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00 };
+      byte[] expanded = hrpExpand(hrp);
+      byte[] values = new byte[zeroes.length + expanded.length + data.length];
 
-        return ret;
-    }
+      System.arraycopy(expanded, 0, values, 0, expanded.length);
+      System.arraycopy(data, 0, values, expanded.length, data.length);
+      System.arraycopy(zeroes, 0, values, expanded.length + data.length, zeroes.length);
+
+      int _const = (spec == Bech32.BECH32M ? BECH32M_CONST : Bech32.BECH32);
+
+      int polymod = polymod(values) ^ _const;
+      byte[] ret = new byte[6];
+      for(int i = 0; i < ret.length; i++)   {
+          ret[i] = (byte)((polymod >> 5 * (5 - i)) & 0x1f);
+      }
+
+      return ret;
+  }
 
 }

--- a/src/main/java/com/samourai/wallet/segwit/bech32/Bech32Segwit.java
+++ b/src/main/java/com/samourai/wallet/segwit/bech32/Bech32Segwit.java
@@ -6,120 +6,135 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.samourai.wallet.util.Triple;
+
 public class Bech32Segwit {
 
-    public static Pair<Byte, byte[]> decode(String hrp, String addr) throws Exception {
+  public static Pair<Byte, byte[]> decode(String hrp, String addr)  {
 
-        Pair<String, byte[]> p = Bech32.bech32Decode(addr);
+      Triple<String, byte[], Integer> p = Bech32.bech32Decode(addr);
+      if(p == null)  {
+        return null;
+      }
 
-        String hrpgotStr =  p.getLeft();
-        if(hrpgotStr == null)  {
+      String hrpgotStr =  p.getLeft();
+      if(hrpgotStr == null)  {
+        return null;
+      }
+      if (!hrp.equalsIgnoreCase(hrpgotStr))    {
+        return null;
+      }
+      if (!hrpgotStr.equalsIgnoreCase("bc") && !hrpgotStr.equalsIgnoreCase("tb"))    {
+        return null;
+      }
+
+      byte[] data = p.getMiddle();
+      List<Byte> progBytes = new ArrayList<Byte>();
+      for(int i = 1; i < data.length; i++) {
+          progBytes.add(data[i]);
+      }
+      byte[] decoded = convertBits(progBytes, 5, 8, false);
+      if(decoded.length < 2 || decoded.length > 40)   {
+          return null;
+      }
+
+      byte witnessVersion = data[0];
+      if (witnessVersion > (byte)16)   {
+          return null;
+      }
+
+      if (witnessVersion == (byte)0x00 && decoded.length != 20 && decoded.length != 32)   {
+          return null;
+      }
+
+      if ((witnessVersion == (byte)0x00 && p.getRight() != Bech32.BECH32) || (witnessVersion != (byte)0x00 && p.getRight() != Bech32.BECH32M))   {
+          return null;
+      }
+
+      return Pair.of(witnessVersion, decoded);
+  }
+
+  public static String encode(String hrp, byte witnessVersion, byte[] witnessProgram) {
+
+      int spec = ((witnessVersion == (byte)0x00) ? Bech32.BECH32 : Bech32.BECH32M);
+
+      List<Byte> progBytes = new ArrayList<Byte>();
+      for(int i = 0; i < witnessProgram.length; i++) {
+          progBytes.add(witnessProgram[i]);
+      }
+
+      byte[] prog = convertBits(progBytes, 8, 5, true);
+      byte[] data = new byte[1 + prog.length];
+
+      System.arraycopy(new byte[] { witnessVersion }, 0, data, 0, 1);
+      System.arraycopy(prog, 0, data, 1, prog.length);
+
+      String ret = Bech32.bech32Encode(hrp, data, spec);
+      if(ret == null)    {
+          return null;
+      }
+
+      Pair<Byte, byte[]> pair = decode(hrp, ret);
+      return pair == null ? null : ret;
+  }
+
+  private static byte[] convertBits(List<Byte> data, int fromBits, int toBits, boolean pad)  {
+
+      int acc = 0;
+      int bits = 0;
+      int maxv = (1 << toBits) - 1;
+      int max_acc = (1 << (fromBits + toBits - 1)) - 1;
+      List<Byte> ret = new ArrayList<Byte>();
+
+      for(Byte value : data)  {
+
+          short b = (short)(value.byteValue() & 0xff);
+          if (b < 0) {
             return null;
-        }
-        if (!hrp.equalsIgnoreCase(hrpgotStr))    {
-            return null;
-        }
-        if (!hrpgotStr.equalsIgnoreCase("bc") && !hrpgotStr.equalsIgnoreCase("tb"))    {
-            throw new Exception("invalid segwit human readable part");
-        }
+          }
+          else if ((b >> fromBits) > 0) {
+              return null;
+          }
+          else    {
+              ;
+          }
 
-        byte[] data = p.getRight();
-        List<Byte> progBytes = new ArrayList<Byte>();
-        for(int i = 1; i < data.length; i++) {
-            progBytes.add(data[i]);
-        }
-        byte[] decoded = convertBits(progBytes, 5, 8, false);
-        if(decoded.length < 2 || decoded.length > 40)   {
-            throw new Exception("invalid decoded data length");
-        }
+          acc = ((acc << fromBits) | b) & max_acc;
+          bits += fromBits;
+          while (bits >= toBits)  {
+              bits -= toBits;
+              ret.add((byte)((acc >> bits) & maxv));
+          }
+      }
 
-        byte witnessVersion = data[0];
-        if (witnessVersion > 16)   {
-            throw new Exception("invalid decoded witness version");
-        }
+      if(pad && (bits > 0))    {
+          ret.add((byte)((acc << (toBits - bits)) & maxv));
+      }
+      else if (bits >= fromBits || (byte)(((acc << (toBits - bits)) & maxv)) != 0)    {
+          return null;
+      }
+      else    {
+          ;
+      }
 
-        if (witnessVersion == 0 && decoded.length != 20 && decoded.length != 32)   {
-            throw new Exception("decoded witness version 0 with unknown length");
-        }
+      byte[] buf = new byte[ret.size()];
+      for(int i = 0; i < ret.size(); i++) {
+          buf[i] = ret.get(i);
+      }
 
-        return Pair.of(witnessVersion, decoded);
-    }
+      return buf;
+  }
 
-    public static String encode(String hrp, byte witnessVersion, byte[] witnessProgram) throws Exception    {
+  public static byte[] getScriptPubkey(byte witver, byte[] witprog) {
 
-        List<Byte> progBytes = new ArrayList<Byte>();
-        for(int i = 0; i < witnessProgram.length; i++) {
-            progBytes.add(witnessProgram[i]);
-        }
+      byte v = (witver > (byte)0x00) ? (byte)(witver + 0x50) : (byte)0x00;
+      byte[] ver = new byte[] { v, (byte)witprog.length };
 
-        byte[] prog = convertBits(progBytes, 8, 5, true);
-        byte[] data = new byte[1 + prog.length];
+      byte[] ret = new byte[witprog.length + ver.length];
+      System.arraycopy(ver, 0, ret, 0, ver.length);
+      System.arraycopy(witprog, 0, ret, ver.length, witprog.length);
 
-        System.arraycopy(new byte[] { witnessVersion }, 0, data, 0, 1);
-        System.arraycopy(prog, 0, data, 1, prog.length);
-
-        String ret = Bech32.bech32Encode(hrp, data);
-
-        return ret;
-    }
-
-    private static byte[] convertBits(List<Byte> data, int fromBits, int toBits, boolean pad) throws Exception    {
-
-        int acc = 0;
-        int bits = 0;
-        int maxv = (1 << toBits) - 1;
-        List<Byte> ret = new ArrayList<Byte>();
-
-        for(Byte value : data)  {
-
-            short b = (short)(value.byteValue() & 0xff);
-
-            if (b < 0) {
-                throw new Exception();
-            }
-            else if ((b >> fromBits) > 0) {
-                throw new Exception();
-            }
-            else    {
-                ;
-            }
-
-            acc = (acc << fromBits) | b;
-            bits += fromBits;
-            while (bits >= toBits)  {
-                bits -= toBits;
-                ret.add((byte)((acc >> bits) & maxv));
-            }
-        }
-
-        if(pad && (bits > 0))    {
-            ret.add((byte)((acc << (toBits - bits)) & maxv));
-        }
-        else if (bits >= fromBits || (byte)(((acc << (toBits - bits)) & maxv)) != 0)    {
-            return null;
-        }
-        else    {
-            ;
-        }
-
-        byte[] buf = new byte[ret.size()];
-        for(int i = 0; i < ret.size(); i++) {
-            buf[i] = ret.get(i);
-        }
-
-        return buf;
-    }
-
-    public static byte[] getScriptPubkey(byte witver, byte[] witprog) {
-
-        byte v = (witver > 0) ? (byte)(witver + 0x50) : (byte)0;
-        byte[] ver = new byte[] { v, (byte)witprog.length };
-
-        byte[] ret = new byte[witprog.length + ver.length];
-        System.arraycopy(ver, 0, ret, 0, ver.length);
-        System.arraycopy(witprog, 0, ret, ver.length, witprog.length);
-
-        return ret;
-    }
+      return ret;
+  }
 
 }

--- a/src/main/java/com/samourai/wallet/util/AddressFactoryGeneric.java
+++ b/src/main/java/com/samourai/wallet/util/AddressFactoryGeneric.java
@@ -1,0 +1,314 @@
+package com.samourai.wallet.util;
+
+import com.samourai.wallet.hd.*;
+import com.samourai.wallet.segwit.SegwitAddress;
+import com.samourai.whirlpool.client.wallet.beans.WhirlpoolAccount;
+import org.apache.commons.lang3.tuple.Pair;
+import org.bitcoinj.core.NetworkParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class AddressFactoryGeneric {
+    private Logger log = LoggerFactory.getLogger(AddressFactoryGeneric.class);
+
+    public static final int LOOKAHEAD_GAP = 20;
+    public static final int RECEIVE_CHAIN = 0;
+    public static final int CHANGE_CHAIN = 1;
+
+    private HD_Wallet bip44Wallet;
+    private HD_Wallet bip49Wallet;
+    private HD_Wallet bip84Wallet;
+    private NetworkParameters params;
+    private Map<WALLET_INDEX,Integer> highestIdxMap = null; // set from backend by APIFactory
+    private Map<WALLET_INDEX,Integer> walletIdxMap = null; // mirrored with HDWallets instances
+
+    public AddressFactoryGeneric() {
+        this.bip44Wallet = null;
+        this.bip49Wallet = null;
+        this.bip84Wallet = null;
+        this.params = null;
+        highestIdxMap = initMap();
+        walletIdxMap = initMap();
+    }
+
+    public void reset(HD_Wallet bip44Wallet, HD_Wallet bip49Wallet, HD_Wallet bip84Wallet, NetworkParameters params) {
+        if (log.isDebugEnabled()) {
+            log.debug("reset");
+        }
+        if (bip44Wallet == null) {
+            throw new RuntimeException("bip44Wallet is null");
+        }
+        if (bip49Wallet == null) {
+            throw new RuntimeException("bip49Wallet is null");
+        }
+        if (bip84Wallet == null) {
+            throw new RuntimeException("bip84Wallet is null");
+        }
+        this.bip44Wallet = bip44Wallet;
+        this.bip49Wallet = bip49Wallet;
+        this.bip84Wallet = bip84Wallet;
+        this.params = params;
+
+        highestIdxMap = initMap();
+        walletIdxMap = initMap();
+    }
+
+    private static Map<WALLET_INDEX,Integer> initMap() {
+        Map<WALLET_INDEX,Integer> map = new LinkedHashMap<>();
+        for (WALLET_INDEX walletIndex : WALLET_INDEX.values()) {
+            map.put(walletIndex, 0);
+        }
+        return map;
+    }
+
+    public int getIndex(WALLET_INDEX walletIndex) {
+        int idx = 0;
+        try {
+            // max of {highestIdx, walletIdx}
+            int highestIdx = highestIdxMap.get(walletIndex);
+            int walletIdx = getWalletIdx(walletIndex);
+            idx = Math.max(highestIdx, walletIdx);
+            return idx;
+        } catch (Exception e) {
+            log.error("", e);
+        }
+        return idx;
+    }
+
+    public int getIndexAndIncrement(WALLET_INDEX walletIndex) {
+        // get current index
+        int idx = getIndex(walletIndex);
+
+        // increment
+        setWalletIdx(walletIndex, idx+1, false); // no decrement
+        return idx;
+    }
+
+    public void increment(WALLET_INDEX walletIndex) {
+        int idx = getIndex(walletIndex);
+        setWalletIdx(walletIndex, idx+1, false); // no decrement
+    }
+
+    public Pair<Integer, String> getAddress(WALLET_INDEX walletIndex) {
+        return getAddress(walletIndex, walletIndex.getAddressType(), false);
+    }
+
+    public Pair<Integer, String> getAddress(WALLET_INDEX walletIndex, AddressType forcedAddressType) {
+        return getAddress(walletIndex, forcedAddressType, false);
+    }
+
+    public Pair<Integer, String> getAddressAndIncrement(WALLET_INDEX walletIndex) {
+        return getAddress(walletIndex, walletIndex.getAddressType(), true);
+    }
+
+    public Pair<Integer, String> getAddressAndIncrement(WALLET_INDEX walletIndex, AddressType forcedAddressType) {
+        return getAddress(walletIndex, forcedAddressType, true);
+    }
+
+    protected Pair<Integer, String> getAddress(WALLET_INDEX walletIndex, AddressType forcedAddressType, boolean increment)	{
+        int idx = increment ? getIndexAndIncrement(walletIndex) : getIndex(walletIndex);
+        HD_Chain hdChain = getHdCHain(walletIndex);
+        if (hdChain == null) {
+            // may happen on wallet startup
+            throw new RuntimeException("getAddress("+walletIndex+") failed: wallet is null");
+        }
+        HD_Address hdAddress = hdChain.getAddressAt(idx);
+
+        String addr;
+        switch (forcedAddressType) {
+            case LEGACY:
+                addr = hdAddress.getAddressString();
+                break;
+
+            case SEGWIT_COMPAT:
+                SegwitAddress segwitAddress = new SegwitAddress(hdAddress.getPubKey(), params);
+                addr = segwitAddress.getAddressAsString();
+                break;
+
+            default:
+                SegwitAddress segwitAddressNative = new SegwitAddress(hdAddress.getPubKey(), params);
+                addr = segwitAddressNative.getBech32AsString();
+                break;
+        }
+        return Pair.of(idx, addr);
+    }
+
+    public HD_Address get(int accountIdx, int chain, int idx)	{
+
+        HD_Address addr = bip44Wallet.getAccount(accountIdx).getChain(chain).getAddressAt(idx);
+
+        return addr;
+    }
+
+    public HD_Wallet getHdWallet(AddressType addressType) {
+        HD_Wallet hdWallet = null;
+        switch (addressType) {
+            case LEGACY:
+                hdWallet = bip44Wallet;
+                break;
+            case SEGWIT_COMPAT:
+                hdWallet = bip49Wallet;
+                break;
+            case SEGWIT_NATIVE:
+                hdWallet = bip84Wallet;
+                break;
+            default:
+                log.error("unknown AddressType: "+addressType);
+                break;
+        }
+        if (hdWallet == null) {
+            // may happen on wallet startup
+            log.warn("wallet is NULL for "+addressType);
+            return null;
+        }
+        return hdWallet;
+    }
+
+    protected HD_Chain getHdCHain(WALLET_INDEX walletIndex) {
+        int account = walletIndex.getAccountIndex();
+        int chain = walletIndex.getChainIndex();
+        AddressType addressType = walletIndex.getAddressType();
+        HD_Wallet hdWallet = getHdWallet(addressType);
+        if (hdWallet == null) {
+            // may happen on wallet startup
+            return null;
+        }
+        return hdWallet.getAccount(account).getChain(chain);
+    }
+
+    protected int getWalletIdx(WALLET_INDEX walletIndex) {
+        int idx = 0;
+        try {
+            // max of {hdIdx, walletIdx} (they should be mirrored)
+            int hdIdx = getHdIdx(walletIndex);
+            int walletIdx = walletIdxMap.get(walletIndex);
+            idx = Math.max(hdIdx, walletIdx);
+            return idx;
+        } catch (Exception e) {
+            log.error("", e);
+        }
+        return idx;
+    }
+
+    // should only be set by AndroidWalletStateIndexHandler
+    public void setWalletIdx(WALLET_INDEX walletIndex, int value, boolean allowDecrement) {
+        int walletIdx = getWalletIdx(walletIndex);
+        if (walletIdx < value) {
+            // INCREMENT
+
+            // check lookahead gap
+            int highestIdx = highestIdxMap.get(walletIndex);
+            boolean canInc = ((value - highestIdx) < LOOKAHEAD_GAP);
+            if (canInc) {
+                // increment
+                if (log.isDebugEnabled()) {
+                    int oldValue = walletIdxMap.get(walletIndex);
+                    log.debug("set "+walletIndex+".walletIdx "+oldValue+" -> "+value);
+                }
+                walletIdxMap.put(walletIndex, value);
+
+                // apply to HdWallet
+                setHdIdx(walletIndex, value, false); // no decrement
+            } else {
+                log.warn("Cannot increment "+walletIdx+", lookahead gap reached: highestIdx="+highestIdx+", valueToSet="+value);
+            }
+        } else if (walletIdx > value && allowDecrement) {
+            // DECREMENT
+            if (log.isDebugEnabled()) {
+                int oldValue = walletIdxMap.get(walletIndex);
+                log.debug("set "+walletIndex+".walletIdx "+oldValue+" -> "+value);
+            }
+            walletIdxMap.put(walletIndex, value);
+
+            // apply to HDWallet
+            setHdIdx(walletIndex, value, true); // allow decrement
+        }
+    }
+
+    protected int getHdIdx(WALLET_INDEX walletIndex) {
+        int idx = 0;
+        try {
+            HD_Chain hdChain = getHdCHain(walletIndex);
+            if (hdChain != null) {
+                idx = hdChain.getAddrIdx();
+            } else {
+                // may happen on wallet startup
+                log.warn("getHdIdx("+walletIndex+") failed: wallet is null");
+            }
+        } catch (Exception e) {
+            log.error("", e);
+        }
+        return idx;
+    }
+
+    // should only be set by setWalletIdx() to mirror HDWallets instances with walletIdx
+    protected void setHdIdx(WALLET_INDEX walletIndex, int value, boolean allowDecrement) {
+        try {
+            // set hdIdx
+            HD_Chain hdChain = getHdCHain(walletIndex);
+            if (hdChain != null) {
+                int hdIdx = hdChain.getAddrIdx();
+                if (allowDecrement || hdIdx < value) {
+                    if (log.isDebugEnabled()) {
+                        int oldValue = hdChain.getAddrIdx();
+                        log.debug("set "+walletIndex+".hdIdx "+oldValue+" -> "+value);
+                    }
+                    hdChain.setAddrIdx(value);
+                }
+            } else {
+                // this may happen on startup
+                log.warn("cannot setHdIdx("+walletIndex+"): wallet is null");
+            }
+        } catch (Exception e) {
+            log.error("", e);
+        }
+    }
+
+    // should only be set by APIFactory!
+    public void setHighestIdx(WALLET_INDEX walletIndex, int value) {
+        // set highestIdx
+        if (log.isDebugEnabled()) {
+            int oldValue = highestIdxMap.get(walletIndex);
+            log.debug("set "+walletIndex+".highestIdx "+oldValue+" -> "+value);
+        }
+        highestIdxMap.put(walletIndex, value);
+
+        // update walletIdx
+        setWalletIdx(walletIndex, value, false);
+    }
+
+    public String debugIndex(WALLET_INDEX walletIndex) {
+        int highestIdx = highestIdxMap.get(walletIndex);
+        int walletIdx = walletIdxMap.get(walletIndex);
+        int hdIdx = getHdIdx(walletIndex);
+        int index = getIndex(walletIndex);
+        String debugStr = highestIdx+" ; "+walletIdx+" ; "+hdIdx+" => "+index;
+        if (log.isDebugEnabled()) {
+            log.debug(walletIndex+": "+debugStr);
+        }
+        return debugStr;
+    }
+
+    public void wipe() {
+        if (log.isDebugEnabled()) {
+            log.debug("wipe");
+        }
+        bip44Wallet.wipe();
+        for (WALLET_INDEX walletIndex : WALLET_INDEX.values()) {
+            setHighestIdx(walletIndex, 0);
+            setWalletIdx(walletIndex, 0, true);
+        }
+    }
+
+    public String getPub(AddressType addressType, WhirlpoolAccount account) {
+        HD_Wallet hdWallet = getHdWallet(addressType);
+        if (hdWallet == null) {
+            // may happen on wallet startup
+            throw new RuntimeException("getPub("+addressType+","+account+") failed: wallet is null");
+        }
+        return hdWallet.getAccount(account.getAccountIndex()).xpubstr();
+    }
+}

--- a/src/main/java/com/samourai/wallet/util/CryptoTestUtil.java
+++ b/src/main/java/com/samourai/wallet/util/CryptoTestUtil.java
@@ -38,7 +38,7 @@ public class CryptoTestUtil {
 
     public BIP47Wallet generateBip47Wallet(NetworkParameters networkParameters) throws Exception {
         HD_Wallet bip44Wallet = generateWallet(44, networkParameters);
-        BIP47Wallet bip47Wallet = new BIP47Wallet(47, bip44Wallet, 1);
+        BIP47Wallet bip47Wallet = new BIP47Wallet(bip44Wallet);
         return bip47Wallet;
     }
 

--- a/src/main/java/com/samourai/wallet/util/FormatsUtilGeneric.java
+++ b/src/main/java/com/samourai/wallet/util/FormatsUtilGeneric.java
@@ -238,8 +238,8 @@ public class FormatsUtilGeneric {
 		boolean ret = false;
 
 		try	{
-			Pair<String, byte[]> pair0 = Bech32.bech32Decode(address);
-			if(pair0.getLeft() == null || pair0.getRight() == null)	{
+			Triple<String, byte[], Integer> triple0 = Bech32.bech32Decode(address);
+			if(triple0.getLeft() == null || triple0.getMiddle() == null || triple0.getRight() == null)	{
 				ret = false;
 			}
 			else	{

--- a/src/main/java/com/samourai/wallet/util/Triple.java
+++ b/src/main/java/com/samourai/wallet/util/Triple.java
@@ -1,0 +1,31 @@
+package com.samourai.wallet.util;
+
+public class Triple<L, M, R> {
+
+    private L elementLeft = null;
+    private M elementMiddle = null;
+    private R elementRight = null;
+
+    public static <L, M, R> Triple<L, M, R> of(L elementLeft, M elementMiddle, R elementRight) {
+        return new Triple<L, M, R>(elementLeft, elementMiddle, elementRight);
+    }
+
+    public Triple(L elementLeft, M elementMiddle, R elementRight) {
+        this.elementLeft = elementLeft;
+        this.elementMiddle = elementMiddle;
+        this.elementRight = elementRight;
+    }
+
+    public L getLeft() {
+        return elementLeft;
+    }
+
+    public M getMiddle() {
+        return elementMiddle;
+    }
+
+    public R getRight() {
+        return elementRight;
+    }
+
+}

--- a/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexAlreadyUsedEvent.java
+++ b/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexAlreadyUsedEvent.java
@@ -1,0 +1,10 @@
+package com.samourai.whirlpool.client.event;
+
+import com.samourai.whirlpool.client.wallet.WhirlpoolWallet;
+
+public class PostmixIndexAlreadyUsedEvent extends WhirlpoolWalletEvent {
+
+  public PostmixIndexAlreadyUsedEvent(WhirlpoolWallet whirlpoolWallet) {
+    super(whirlpoolWallet);
+  }
+}

--- a/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexFixFailEvent.java
+++ b/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexFixFailEvent.java
@@ -1,0 +1,10 @@
+package com.samourai.whirlpool.client.event;
+
+import com.samourai.whirlpool.client.wallet.WhirlpoolWallet;
+
+public class PostmixIndexFixFailEvent extends WhirlpoolWalletEvent {
+
+  public PostmixIndexFixFailEvent(WhirlpoolWallet whirlpoolWallet) {
+    super(whirlpoolWallet);
+  }
+}

--- a/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexFixProgressEvent.java
+++ b/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexFixProgressEvent.java
@@ -1,0 +1,10 @@
+package com.samourai.whirlpool.client.event;
+
+import com.samourai.whirlpool.client.wallet.WhirlpoolWallet;
+
+public class PostmixIndexFixProgressEvent extends WhirlpoolWalletEvent {
+
+  public PostmixIndexFixProgressEvent(WhirlpoolWallet whirlpoolWallet) {
+    super(whirlpoolWallet);
+  }
+}

--- a/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexFixSuccessEvent.java
+++ b/src/main/java/com/samourai/whirlpool/client/event/PostmixIndexFixSuccessEvent.java
@@ -1,0 +1,10 @@
+package com.samourai.whirlpool.client.event;
+
+import com.samourai.whirlpool.client.wallet.WhirlpoolWallet;
+
+public class PostmixIndexFixSuccessEvent extends WhirlpoolWalletEvent {
+
+  public PostmixIndexFixSuccessEvent(WhirlpoolWallet whirlpoolWallet) {
+    super(whirlpoolWallet);
+  }
+}

--- a/src/main/java/com/samourai/whirlpool/client/utils/DebugUtils.java
+++ b/src/main/java/com/samourai/whirlpool/client/utils/DebugUtils.java
@@ -1,0 +1,368 @@
+package com.samourai.whirlpool.client.utils;
+
+import com.samourai.wallet.api.backend.MinerFeeTarget;
+import com.samourai.wallet.api.backend.beans.UnspentOutput;
+import com.samourai.wallet.api.backend.beans.WalletResponse;
+import com.samourai.wallet.client.BipWalletAndAddressType;
+import com.samourai.wallet.client.indexHandler.IIndexHandler;
+import com.samourai.wallet.hd.AddressType;
+import com.samourai.wallet.hd.Chain;
+import com.samourai.wallet.hd.HD_Address;
+import com.samourai.whirlpool.client.wallet.WhirlpoolWallet;
+import com.samourai.whirlpool.client.wallet.beans.*;
+import java.util.Collection;
+import java.util.Iterator;
+import java8.util.Comparators;
+import java8.util.function.Function;
+import java8.util.function.Predicate;
+import java8.util.stream.Collectors;
+import java8.util.stream.StreamSupport;
+import org.apache.commons.lang3.StringUtils;
+import org.bitcoinj.core.NetworkParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DebugUtils {
+  private static final Logger log = LoggerFactory.getLogger(DebugUtils.class);
+
+  public static String getDebug(WhirlpoolWallet whirlpoolWallet) {
+    StringBuilder sb = new StringBuilder("\n");
+    sb.append("now = " + ClientUtils.dateToString(System.currentTimeMillis()));
+    if (whirlpoolWallet != null) {
+      sb.append(getDebugWallet(whirlpoolWallet));
+      sb.append(getDebugUtxos(whirlpoolWallet));
+      sb.append(getDebugMixingThreads(whirlpoolWallet));
+    } else {
+      sb.append("WhirlpoolWallet is closed.\n");
+    }
+    sb.append(getDebugSystem());
+    return sb.toString();
+  }
+
+  public static String getDebugWallet(WhirlpoolWallet whirlpoolWallet) {
+    StringBuilder sb = new StringBuilder().append("\n");
+
+    // receive address
+    AddressType depositAddressType = AddressType.SEGWIT_NATIVE;
+    BipWalletAndAddressType receiveWallet =
+        whirlpoolWallet.getWalletSupplier().getWallet(WhirlpoolAccount.DEPOSIT, depositAddressType);
+    HD_Address hdAddress = receiveWallet.getNextAddress(false);
+    String receiveAddress = hdAddress.getAddressString(depositAddressType);
+    String receivePath = hdAddress.getPathFull(depositAddressType);
+
+    sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" + "\n");
+    sb.append("⣿ RECEIVE ADDRESS" + "\n");
+    sb.append(" • Address: " + receiveAddress + "\n");
+    sb.append(" • Path: " + receivePath + "\n");
+
+    // balance
+    sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" + "\n");
+    sb.append("⣿ WALLET BALANCE:" + "\n");
+    for (WhirlpoolAccount account : WhirlpoolAccount.values()) {
+      Collection<WhirlpoolUtxo> utxos = whirlpoolWallet.getUtxoSupplier().findUtxos(account);
+      sb.append(" • " + account + ": " + utxos.size() + " utxos\n");
+
+      for (AddressType addressType : account.getAddressTypes()) {
+        utxos = whirlpoolWallet.getUtxoSupplier().findUtxos(addressType, account);
+        BipWalletAndAddressType wallet =
+            whirlpoolWallet.getWalletSupplier().getWallet(account, addressType);
+        sb.append(
+            "___"
+                + account
+                + "/"
+                + addressType
+                + ": "
+                + utxos.size()
+                + " utxos"
+                + ", pub="
+                + ClientUtils.maskString(wallet.getPub())
+                + "\n");
+
+        for (Chain chain : Chain.values()) {
+          IIndexHandler indexHandler =
+              whirlpoolWallet
+                  .getWalletStateSupplier()
+                  .getIndexHandlerWallet(account, addressType, chain);
+          int index = indexHandler.get();
+          sb.append("______.index[" + chain + "] = " + index + "\n");
+        }
+      }
+    }
+    sb.append(
+        " • TOTAL = "
+            + ClientUtils.satToBtc(whirlpoolWallet.getUtxoSupplier().getBalanceTotal())
+            + " BTC"
+            + "\n");
+    sb.append("");
+
+    // chain status
+    WalletResponse.InfoBlock latestBlock = whirlpoolWallet.getChainSupplier().getLatestBlock();
+    sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" + "\n");
+    sb.append("⣿ LATEST BLOCK:" + "\n");
+    sb.append(" • Height: " + latestBlock.height + "\n");
+    sb.append(" • Hash: " + latestBlock.hash + "\n");
+    sb.append(" • Time: " + ClientUtils.dateToString(latestBlock.time * 1000) + "\n");
+    sb.append("");
+
+    // chain
+    sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" + "\n");
+    sb.append("⣿ MINER FEE:" + "\n");
+    for (MinerFeeTarget minerFeeTarget : MinerFeeTarget.values()) {
+      long value = whirlpoolWallet.getMinerFeeSupplier().getFee(minerFeeTarget);
+      sb.append("fee[" + minerFeeTarget + "] = " + value + "\n");
+    }
+    return sb.toString();
+  }
+
+  public static String getDebugUtxos(WhirlpoolWallet whirlpoolWallet) {
+    StringBuilder sb = new StringBuilder().append("\n");
+    for (WhirlpoolAccount account : WhirlpoolAccount.values()) {
+      sb.append(getDebugUtxos(whirlpoolWallet, account) + "\n");
+    }
+    return sb.toString();
+  }
+
+  private static String getDebugUtxos(WhirlpoolWallet whirlpoolWallet, WhirlpoolAccount account) {
+    StringBuilder sb = new StringBuilder().append("\n");
+
+    Collection<WhirlpoolUtxo> utxos = whirlpoolWallet.getUtxoSupplier().findUtxos(account);
+    int latestBlockHeight = whirlpoolWallet.getChainSupplier().getLatestBlock().height;
+    try {
+      sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿");
+      double balance = ClientUtils.satToBtc(whirlpoolWallet.getUtxoSupplier().getBalanceTotal());
+      String lastUpdate =
+          ClientUtils.dateToString(whirlpoolWallet.getUtxoSupplier().getLastUpdate());
+      sb.append(
+          "⣿ "
+              + account.name()
+              + " UTXOS ("
+              + utxos.size()
+              + ") ("
+              + balance
+              + "btc at "
+              + lastUpdate
+              + "):");
+      sb.append(getDebugUtxos(utxos, latestBlockHeight));
+    } catch (Exception e) {
+      log.error("", e);
+    }
+    return sb.toString();
+  }
+
+  public static String getDebugUtxos(Collection<WhirlpoolUtxo> utxos, int latestBlockHeight) {
+    String lineFormat =
+        "| %10s | %7s | %68s | %45s | %13s | %27s | %14s | %8s | %8s | %4s | %19s | %19s |\n";
+    StringBuilder sb = new StringBuilder().append("\n");
+    sb.append(
+        String.format(
+                lineFormat,
+                "BALANCE",
+                "CONFIRM",
+                "UTXO",
+                "ADDRESS",
+                "TYPE",
+                "PATH",
+                "STATUS",
+                "MIXABLE",
+                "POOL",
+                "MIXS",
+                "ACTIVITY",
+                "ERROR")
+            + "\n");
+    sb.append(
+        String.format(lineFormat, "(btc)", "", "", "", "", "", "", "", "", "", "", "") + "\n");
+    Iterator var3 = utxos.iterator();
+
+    while (var3.hasNext()) {
+      WhirlpoolUtxo whirlpoolUtxo = (WhirlpoolUtxo) var3.next();
+      WhirlpoolUtxoState utxoState = whirlpoolUtxo.getUtxoState();
+      UnspentOutput o = whirlpoolUtxo.getUtxo();
+      String utxo = o.tx_hash + ":" + o.tx_output_n;
+      String mixableStatusName =
+          utxoState.getMixableStatus() != null ? utxoState.getMixableStatus().name() : "-";
+      Long lastActivity = whirlpoolUtxo.getUtxoState().getLastActivity();
+      String activity =
+          (lastActivity != null ? ClientUtils.dateToString(lastActivity) + " " : "")
+              + (whirlpoolUtxo.getUtxoState().getMessage() != null
+                  ? whirlpoolUtxo.getUtxoState().getMessage()
+                  : "");
+      Long lastError = whirlpoolUtxo.getUtxoState().getLastError();
+      String error =
+          (lastError != null ? ClientUtils.dateToString(lastError) + " " : "")
+              + (whirlpoolUtxo.getUtxoState().getError() != null
+                  ? whirlpoolUtxo.getUtxoState().getError()
+                  : "");
+      sb.append(
+          String.format(
+              lineFormat,
+              ClientUtils.satToBtc(o.value),
+              whirlpoolUtxo.computeConfirmations(latestBlockHeight),
+              utxo,
+              o.addr,
+              whirlpoolUtxo.getAddressType(),
+              whirlpoolUtxo.getPathFull(),
+              utxoState.getStatus().name(),
+              mixableStatusName,
+              whirlpoolUtxo.getUtxoState().getPoolId() != null
+                  ? whirlpoolUtxo.getUtxoState().getPoolId()
+                  : "-",
+              whirlpoolUtxo.getMixsDone(),
+              activity,
+              error));
+    }
+    return sb.toString();
+  }
+
+  public static String getDebugUtxos(
+      Collection<UnspentOutput> utxos, int purpose, int accountIndex, NetworkParameters params) {
+    String lineFormat = "| %10s | %7s | %68s | %45s | %18s |\n";
+    StringBuilder sb = new StringBuilder().append("\n");
+    sb.append(
+        String.format(lineFormat, "BALANCE", "CONFIRM", "UTXO", "ADDRESS", "TYPE", "PATH") + "\n");
+    sb.append(String.format(lineFormat, "(btc)", "", "", "", "", "") + "\n");
+    for (UnspentOutput o : utxos) {
+      String utxo = o.tx_hash + ":" + o.tx_output_n;
+      sb.append(
+          String.format(
+              lineFormat,
+              ClientUtils.satToBtc(o.value),
+              o.confirmations,
+              utxo,
+              o.addr,
+              AddressType.findByAddress(o.addr, params),
+              o.getPathFull(purpose, accountIndex)));
+    }
+    return sb.toString();
+  }
+
+  public static String getDebugSystem() {
+    StringBuilder sb = new StringBuilder().append("\n");
+    final ThreadGroup tg = Thread.currentThread().getThreadGroup();
+    Collection<Thread> threadSet =
+        StreamSupport.stream(Thread.getAllStackTraces().keySet())
+            .filter(
+                new Predicate<Thread>() {
+                  @Override
+                  public boolean test(Thread t) {
+                    return t.getThreadGroup() == tg;
+                  }
+                })
+            .sorted(
+                Comparators.comparing(
+                    new Function<Thread, String>() {
+                      @Override
+                      public String apply(Thread t) {
+                        return t.getName().toLowerCase();
+                      }
+                    }))
+            .collect(Collectors.<Thread>toList());
+    sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" + "\n");
+    sb.append("⣿ SYSTEM THREADS:" + "\n");
+    int i = 0;
+    for (Thread t : threadSet) {
+      sb.append("#" + i + " " + t + ":" + "" + t.getState() + "\n");
+      // show trace for BLOCKED
+      if (Thread.State.BLOCKED.equals(t.getState())) {
+        sb.append(StringUtils.join(t.getStackTrace(), "\n"));
+      }
+      i++;
+    }
+
+    // memory
+    Runtime rt = Runtime.getRuntime();
+    long total = rt.totalMemory();
+    long free = rt.freeMemory();
+    long used = total - free;
+    sb.append(
+        "⣿ MEM USE: "
+            + ClientUtils.bytesToMB(used)
+            + "M/"
+            + ClientUtils.bytesToMB(total)
+            + "M"
+            + "\n");
+
+    return sb.toString();
+  }
+
+  public static String getDebugMixingThreads(WhirlpoolWallet whirlpoolWallet) {
+    StringBuilder sb = new StringBuilder().append("\n");
+    MixingState mixingState = whirlpoolWallet.getMixingState();
+    try {
+      sb.append("⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿" + "\n");
+      sb.append("⣿ MIXING THREADS:" + "\n");
+
+      String lineFormat =
+          "| %25s | %8s | %10s | %10s | %8s | %68s | %14s | %8s | %6s | %19s | %19s |\n";
+      sb.append(
+          String.format(
+                  lineFormat,
+                  "STATUS",
+                  "SINCE",
+                  "ACCOUNT",
+                  "BALANCE",
+                  "CONFIRMS",
+                  "UTXO",
+                  "PATH",
+                  "POOL",
+                  "MIXS",
+                  "ACTIVITY",
+                  "ERROR")
+              + "\n");
+
+      long now = System.currentTimeMillis();
+      for (WhirlpoolUtxo whirlpoolUtxo : mixingState.getUtxosMixing()) {
+        MixProgress mixProgress = whirlpoolUtxo.getUtxoState().getMixProgress();
+        String progress = mixProgress != null ? mixProgress.toString() : "";
+        String since = mixProgress != null ? ((now - mixProgress.getSince()) / 1000) + "s" : "";
+        UnspentOutput o = whirlpoolUtxo.getUtxo();
+        String utxo = o.tx_hash + ":" + o.tx_output_n;
+        Long lastActivity = whirlpoolUtxo.getUtxoState().getLastActivity();
+        String activity =
+            (lastActivity != null ? ClientUtils.dateToString(lastActivity) + " " : "")
+                + (whirlpoolUtxo.getUtxoState().getMessage() != null
+                    ? whirlpoolUtxo.getUtxoState().getMessage()
+                    : "");
+        Long lastError = whirlpoolUtxo.getUtxoState().getLastError();
+        String error =
+            (lastError != null ? ClientUtils.dateToString(lastError) + " " : "")
+                + (whirlpoolUtxo.getUtxoState().getError() != null
+                    ? whirlpoolUtxo.getUtxoState().getError()
+                    : "");
+        sb.append(
+            String.format(
+                    lineFormat,
+                    progress,
+                    since,
+                    whirlpoolUtxo.getAccount().name(),
+                    ClientUtils.satToBtc(o.value),
+                    o.confirmations,
+                    utxo,
+                    o.getPath(),
+                    mixProgress.getPoolId() != null ? mixProgress.getPoolId() : "-",
+                    whirlpoolUtxo.getMixsDone(),
+                    activity,
+                    error)
+                + "\n");
+      }
+    } catch (Exception e) {
+      log.error("", e);
+    }
+    sb.append(
+        "Mixing: "
+            + mixingState.getNbMixing()
+            + " ("
+            + mixingState.getNbMixingMustMix()
+            + "+"
+            + mixingState.getNbMixingLiquidity()
+            + ")\n");
+    sb.append(
+        "Queued: "
+            + mixingState.getNbQueued()
+            + " ("
+            + mixingState.getNbQueuedMustMix()
+            + "+"
+            + mixingState.getNbQueuedLiquidity()
+            + ")\n");
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/samourai/whirlpool/client/wallet/WalletAggregateService.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/WalletAggregateService.java
@@ -11,6 +11,7 @@ import com.samourai.wallet.util.FeeUtil;
 import com.samourai.wallet.util.FormatsUtilGeneric;
 import com.samourai.whirlpool.client.exception.NotifiableException;
 import com.samourai.whirlpool.client.utils.ClientUtils;
+import com.samourai.whirlpool.client.utils.DebugUtils;
 import com.samourai.whirlpool.client.wallet.beans.WhirlpoolAccount;
 import com.samourai.whirlpool.client.wallet.beans.WhirlpoolUtxo;
 import org.bitcoinj.core.NetworkParameters;
@@ -98,8 +99,9 @@ public class WalletAggregateService {
               + ":"
               + destinationWallet.getAddressType()
               + "):");
-      ClientUtils.logWhirlpoolUtxos(
-          utxos, whirlpoolWallet.getChainSupplier().getLatestBlock().height);
+      log.info(
+          DebugUtils.getDebugUtxos(
+              utxos, whirlpoolWallet.getChainSupplier().getLatestBlock().height));
     }
 
     boolean success = false;

--- a/src/main/java/com/samourai/whirlpool/client/wallet/beans/WhirlpoolUtxo.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/beans/WhirlpoolUtxo.java
@@ -150,10 +150,23 @@ public class WhirlpoolUtxo {
         + ": "
         + utxo.toString()
         + ", blockHeight="
-        + (blockHeight != null ? blockHeight : "unconfirmed")
+        + (blockHeight != null ? blockHeight : "null")
+        + ", state={"
         + utxoState
-        + ", utxoConfig={"
+        + "}, utxoConfig={"
         + utxoConfig
         + "}";
+  }
+
+  public String getDebug() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(toString());
+    sb.append(", path=").append(getPathFull());
+
+    String poolId = getUtxoState().getPoolId();
+    sb.append(", poolId=").append((poolId != null ? poolId : "null"));
+    sb.append(", mixsDone=").append(getMixsDone());
+    sb.append(", state={").append(getUtxoState().toString()).append("}");
+    return sb.toString();
   }
 }

--- a/src/main/java/com/samourai/whirlpool/client/wallet/beans/WhirlpoolUtxoState.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/beans/WhirlpoolUtxoState.java
@@ -2,6 +2,7 @@ package com.samourai.whirlpool.client.wallet.beans;
 
 import com.samourai.whirlpool.client.mix.MixParams;
 import com.samourai.whirlpool.client.mix.listener.MixStep;
+import com.samourai.whirlpool.client.utils.ClientUtils;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
@@ -50,7 +51,8 @@ public class WhirlpoolUtxoState {
       WhirlpoolUtxoStatus status,
       boolean updateLastActivity,
       MixProgress mixProgress,
-      String error) {
+      String error,
+      boolean updateLastError) {
     this.status = status;
     this.mixProgress = mixProgress;
     if (mixProgress != null) {
@@ -59,7 +61,7 @@ public class WhirlpoolUtxoState {
       if (mixStep != MixStep.SUCCESS) this.message = message;
     }
     this.error = error;
-    if (error != null) {
+    if (updateLastError) {
       setLastError();
     }
     if (updateLastActivity) {
@@ -73,19 +75,20 @@ public class WhirlpoolUtxoState {
       boolean updateLastActivity,
       MixParams mixParams,
       MixStep mixStep) {
-    setStatus(status, updateLastActivity, new MixProgress(mixParams, mixStep), null);
+    setStatus(status, updateLastActivity, new MixProgress(mixParams, mixStep), null, false);
   }
 
   public void setStatusError(WhirlpoolUtxoStatus status, String error) {
-    setStatus(status, true, null, error);
+    setStatus(status, true, null, error, true);
   }
 
   public void setStatusMixingError(WhirlpoolUtxoStatus status, MixParams mixParams, String error) {
-    setStatus(status, true, new MixProgress(mixParams, MixStep.FAIL), error);
+    setStatus(status, true, new MixProgress(mixParams, MixStep.FAIL), error, true);
   }
 
-  public void setStatus(WhirlpoolUtxoStatus status, boolean updateLastActivity) {
-    setStatus(status, updateLastActivity, null, null);
+  public void setStatus(
+      WhirlpoolUtxoStatus status, boolean updateLastActivity, boolean clearError) {
+    setStatus(status, updateLastActivity, null, clearError ? null : error, false);
   }
 
   public MixProgress getMixProgress() {
@@ -151,6 +154,7 @@ public class WhirlpoolUtxoState {
         + (mixableStatus != null ? mixableStatus : "null")
         + (hasMessage() ? ", message=" + message : "")
         + (hasError() ? ", error=" + error : "")
-        + (lastError != null ? ", lastError=" + lastError : "");
+        + (lastActivity != null ? ", lastActivity=" + ClientUtils.dateToString(lastActivity) : "")
+        + (lastError != null ? ", lastError=" + ClientUtils.dateToString(lastError) : "");
   }
 }

--- a/src/main/java/com/samourai/whirlpool/client/wallet/data/dataSource/DataSourceWithStrictMode.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/data/dataSource/DataSourceWithStrictMode.java
@@ -1,0 +1,8 @@
+package com.samourai.whirlpool.client.wallet.data.dataSource;
+
+import java.util.List;
+
+public interface DataSourceWithStrictMode {
+
+  void pushTx(String txHex, List<Integer> strictModeVouts) throws Exception;
+}

--- a/src/main/java/com/samourai/whirlpool/client/wallet/data/dataSource/MixsDoneResyncManager.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/data/dataSource/MixsDoneResyncManager.java
@@ -14,9 +14,14 @@ public class MixsDoneResyncManager {
   public MixsDoneResyncManager() {}
 
   public void resync(Collection<WhirlpoolUtxo> postmixUtxos, Map<String, TxsResponse.Tx> txs) {
+    resync(postmixUtxos, txs, 0);
+  }
+
+  public void resync(
+      Collection<WhirlpoolUtxo> postmixUtxos, Map<String, TxsResponse.Tx> txs, int adjustCounter) {
     log.info("Resynchronizing mix counters...");
 
-    int fixedUtxos = 0;
+    int fixedUtxos = adjustCounter;
     for (WhirlpoolUtxo whirlpoolUtxo : postmixUtxos) {
       int mixsDone = recountMixsDone(whirlpoolUtxo, txs);
       if (mixsDone != whirlpoolUtxo.getMixsDone()) {
@@ -38,15 +43,14 @@ public class MixsDoneResyncManager {
 
   private int recountMixsDone(WhirlpoolUtxo whirlpoolUtxo, Map<String, TxsResponse.Tx> txs) {
     int mixsDone = 0;
-
     String txid = whirlpoolUtxo.getUtxo().tx_hash;
     while (true) {
       TxsResponse.Tx tx = txs.get(txid);
-      mixsDone++;
       if (tx == null || tx.inputs == null || tx.inputs.length == 0) {
         return mixsDone;
       }
       txid = tx.inputs[0].prev_out.txid;
+      mixsDone++;
     }
   }
 }

--- a/src/main/java/com/samourai/whirlpool/client/wallet/data/dataSource/WalletResponseDataSource.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/data/dataSource/WalletResponseDataSource.java
@@ -175,10 +175,10 @@ public abstract class WalletResponseDataSource implements DataSource {
         walletStateSupplier
             .getIndexHandlerWallet(
                 bipWallet.getAccount(), bipWallet.getAddressType(), Chain.RECEIVE)
-            .set(address.account_index);
+            .set(address.account_index, false);
         walletStateSupplier
             .getIndexHandlerWallet(bipWallet.getAccount(), bipWallet.getAddressType(), Chain.CHANGE)
-            .set(address.change_index);
+            .set(address.change_index, false);
       } else {
         log.error("No wallet found for: " + pub);
       }

--- a/src/main/java/com/samourai/whirlpool/client/wallet/data/walletState/PersistableWalletStateSupplier.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/data/walletState/PersistableWalletStateSupplier.java
@@ -55,7 +55,7 @@ public class PersistableWalletStateSupplier extends BasicPersistableSupplier<Wal
       }
 
       @Override
-      public void set(int value) {
+      protected void set(int value) {
         getValue().set(persistKey, value);
         if (log.isDebugEnabled()) {
           log.debug("set: [" + persistKey + "]=" + value);

--- a/src/main/java/com/samourai/whirlpool/client/wallet/data/walletState/WalletStateData.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/data/walletState/WalletStateData.java
@@ -53,7 +53,7 @@ public class WalletStateData extends PersistableData {
   protected synchronized void set(String key, int value) {
     int currentIndex = get(key, 0);
     if (currentIndex > value) {
-      log.warn("Rollbacking index: " + currentIndex + " => " + value);
+      log.warn("Rollbacking [" + key + "]: " + currentIndex + " => " + value);
     }
 
     items.put(key, value);

--- a/src/main/java/com/samourai/whirlpool/client/wallet/orchestrator/MixOrchestrator.java
+++ b/src/main/java/com/samourai/whirlpool/client/wallet/orchestrator/MixOrchestrator.java
@@ -122,7 +122,7 @@ public abstract class MixOrchestrator extends AbstractOrchestrator {
             new Consumer<WhirlpoolUtxo>() {
               @Override
               public void accept(WhirlpoolUtxo whirlpoolUtxo) {
-                whirlpoolUtxo.getUtxoState().setStatus(WhirlpoolUtxoStatus.READY, false);
+                whirlpoolUtxo.getUtxoState().setStatus(WhirlpoolUtxoStatus.READY, false, false);
               }
             });
   }
@@ -369,12 +369,16 @@ public abstract class MixOrchestrator extends AbstractOrchestrator {
     WhirlpoolUtxoStatus utxoStatus = utxoState.getStatus();
     if (WhirlpoolUtxoStatus.MIX_QUEUE.equals(utxoStatus)) {
       // already queued
-      log.warn("mixQueue ignored: utxo already queued for " + whirlpoolUtxo);
+      if (log.isDebugEnabled()) {
+        log.debug("mixQueue ignored: utxo already queued for " + whirlpoolUtxo);
+      }
       return;
     }
     if (data.getMixing(whirlpoolUtxo.getUtxo()) != null
         || WhirlpoolUtxoStatus.MIX_SUCCESS.equals(utxoStatus)) {
-      log.warn("mixQueue ignored: utxo already mixing for " + whirlpoolUtxo);
+      if (log.isDebugEnabled()) {
+        log.debug("mixQueue ignored: utxo already mixing for " + whirlpoolUtxo);
+      }
       return;
     }
     if (!WhirlpoolUtxoStatus.MIX_FAILED.equals(utxoStatus)
@@ -387,7 +391,7 @@ public abstract class MixOrchestrator extends AbstractOrchestrator {
     }
 
     // add to queue
-    utxoState.setStatus(WhirlpoolUtxoStatus.MIX_QUEUE, false);
+    utxoState.setStatus(WhirlpoolUtxoStatus.MIX_QUEUE, false, false);
     data.getMixingState().incrementUtxoQueued(whirlpoolUtxo);
     if (notify) {
       notifyOrchestrator();
@@ -423,7 +427,7 @@ public abstract class MixOrchestrator extends AbstractOrchestrator {
       boolean wasQueued = WhirlpoolUtxoStatus.MIX_QUEUE.equals(utxoState.getStatus());
       WhirlpoolUtxoStatus utxoStatus =
           cancel ? WhirlpoolUtxoStatus.READY : WhirlpoolUtxoStatus.STOP;
-      utxoState.setStatus(utxoStatus, false);
+      utxoState.setStatus(utxoStatus, false, false);
 
       // recount QUEUE if it was queued
       if (wasQueued) {


### PR DESCRIPTION
- add config.postmixIndexAutoFix + associated events
- detect unsupported Java versions on whirlpool startup
- fix WalletResponseDataSource erasing local indexes with highest used wallet index
- less unnecessary warn/error logs
- add whirlpoolWallet.getDebug()
- fix failed mix utxo not re-queued
- keep utxo.error until new mix
- fix resyncMixsDone() for external datasources
